### PR TITLE
Better header behavior for scheduler and daily view

### DIFF
--- a/src/component/QCalendarDaily.js
+++ b/src/component/QCalendarDaily.js
@@ -147,8 +147,8 @@ export default CalendarIntervals.extend({
         })
       }), [
         this.columnHeaderBefore === true ? this.__renderColumnHeaderBefore(h, day, idx) : '',
-        this.__renderHeadWeekday(h, day),
-        this.__renderHeadDayBtn(h, day),
+        !slot ? this.__renderHeadWeekday(h, day) : '',
+        !slot ? this.__renderHeadDayBtn(h, day) : '',
         slot ? slot(scope) : '',
         this.columnHeaderAfter === true ? this.__renderColumnHeaderAfter(h, day, idx) : ''
       ])

--- a/src/component/QCalendarDaily.js
+++ b/src/component/QCalendarDaily.js
@@ -147,8 +147,8 @@ export default CalendarIntervals.extend({
         })
       }), [
         this.columnHeaderBefore === true ? this.__renderColumnHeaderBefore(h, day, idx) : '',
-        !this.hideHeader ? this.__renderHeadWeekday(h, day) : '',
-        !this.hideHeader ? this.__renderHeadDayBtn(h, day) : '',
+        this.__renderHeadWeekday(h, day),
+        this.__renderHeadDayBtn(h, day),
         slot ? slot(scope) : '',
         this.columnHeaderAfter === true ? this.__renderColumnHeaderAfter(h, day, idx) : ''
       ])
@@ -438,7 +438,7 @@ export default CalendarIntervals.extend({
         value: this.onResize
       }]
     }, [
-      this.__renderHead(h),
+      !this.hideHeader ? this.__renderHead(h) : '',
       this.__renderBody(h)
     ])
   }

--- a/src/component/QCalendarScheduler.js
+++ b/src/component/QCalendarScheduler.js
@@ -366,7 +366,7 @@ export default CalendarScheduler.extend({
       style = Object.assign(style, styler(scope))
 
       const data = {
-        key: resource.label + '-' + idx,
+        key: resource[this.resourceKey] + '-' + idx,
         staticClass: 'q-calendar-scheduler__day-resource',
         class: {
           'q-calendar-scheduler__day-resource--droppable': dragOver

--- a/src/component/QCalendarScheduler.js
+++ b/src/component/QCalendarScheduler.js
@@ -165,10 +165,10 @@ export default CalendarScheduler.extend({
         on: this.getDefaultMouseEventHandlers(':day', _event => scope)
       }), [
         this.columnHeaderBefore === true ? this.__renderColumnHeaderBefore(h, day, idx) : '',
-        this.__renderHeadWeekday(h, day, idx),
-        this.__renderHeadDayBtn(h, day, idx),
-        this.columnHeaderAfter === true ? this.__renderColumnHeaderAfter(h, day, idx) : '',
-        slot ? slot(scope) : ''
+        !slot ? this.__renderHeadWeekday(h, day, idx) : '',
+        !slot ? this.__renderHeadDayBtn(h, day, idx) : '',
+        slot ? slot(scope) : '',
+        this.columnHeaderAfter === true ? this.__renderColumnHeaderAfter(h, day, idx) : ''
       ])
     },
 

--- a/src/component/utils/props.js
+++ b/src/component/utils/props.js
@@ -108,6 +108,10 @@ export default {
   },
   scheduler: {
     resources: Array,
+    resourceKey: {
+      type: String,
+      default: 'label'
+    },
     maxDays: {
       type: Number,
       default: 7


### PR DESCRIPTION
This PR has a few minor changes, as discussed with @hawkeye64
### Changes
#### Reverts some changes from #25 
hideHeader will now hide whole header, including slots.
#### Correct headerColumnAfter slot posisiton
Will now render after main header slot
#### Do not render day name and day btn in day and scheduler view when header slot is used
In scheduler and and day views, do not render headWeekday and headDayBtn if the header slot is used.
These will still render if the header-before or header-after slots are used
#### Add resourceKey prop for scheduler view
Currenlty schedule view uses the label property of the resource object as key for the loop.
This prop allows the use of another property as a unique key. The default value is "label", so if the prop is ommited behavior is unchanged. This prop is equivalent to the QTable rowKey prop

### TODO: Review month view
Add slot for weekday label in month view, review slots in month view (currently looks pretty good, might add a "don't render default day content" property and call it a day.)
Will take a look when I get around to using the month view in the next few days.
This will be a separate PR
